### PR TITLE
Make tests Python 3 compatible.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -46,7 +46,7 @@ class TestHTTPError(testing.AsyncHTTPTestCase):
     def test_tornado_thrown_exception(self):
         response = self.fetch('/')
         expected = {'message': 'Unexpected Error', 'type': 'Bad Request'}
-        self.assertEqual(json.loads(response.body), expected)
+        self.assertEqual(json.loads(response.body.decode('utf-8')), expected)
 
 
 class TestCustomExceptions(testing.AsyncHTTPTestCase):
@@ -61,7 +61,7 @@ class TestCustomExceptions(testing.AsyncHTTPTestCase):
             'type': 'FailureError',
             'documentation_url': 'http://www.example.com',
         }
-        self.assertEqual(json.loads(response.body), expected)
+        self.assertEqual(json.loads(response.body.decode('utf-8')), expected)
 
 
 class TestUnexpectedError(testing.AsyncHTTPTestCase):
@@ -75,4 +75,4 @@ class TestUnexpectedError(testing.AsyncHTTPTestCase):
             'message': 'Unexpected Error',
             'type': 'Internal Server Error'
         }
-        self.assertEqual(json.loads(response.body), expected)
+        self.assertEqual(json.loads(response.body.decode('utf-8')), expected)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py26,py27,py33,py34,pypy
+indexserver =
+	default = https://warehouse.python.org/simple
+
+[testenv]
+commands = nosetests tests
+deps =
+	-rtest-requirements.txt
+	tox
+
+[testenv:py27]
+deps =
+	{[testenv]deps}
+	mock
+
+[testenv:py26]
+deps =
+	{[testenv:py27]deps}
+	unittest2


### PR DESCRIPTION
_tests.py_ contained a bunch of `json.loads(response.body)` where `response.body` is a byte stream.  This PR decodes to `utf-8` before passing it on to the JSON decoder.
